### PR TITLE
Datasf 1011 handle timeseries

### DIFF
--- a/src/shared/scrapers/US/CA/san-francisco-county.js
+++ b/src/shared/scrapers/US/CA/san-francisco-county.js
@@ -1,6 +1,7 @@
 import * as fetch from '../../../lib/fetch/index.js';
 import datetime from '../../../lib/datetime/index.js';
 import maintainers from '../../../lib/maintainers.js';
+import * as parse from '../../../lib/parse.js';
 
 // Set county to this if you only have state data, but this isn't the entire state
 // const UNASSIGNED = '(unassigned)';
@@ -36,28 +37,68 @@ const scraper = {
     patients: 'https://data.sfgov.org/resource/nxjg-bhem.json',
     tests: 'https://data.sfgov.org/resource/nfpa-mg4g.json'
   },
+  _getScrapeDateString: (proposed, allDates) => {
+    let scrapeDate = proposed;
+    let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
+    const firstDateInTimeseries = new Date(allDates[0]);
+    const lastDateInTimeseries = new Date(allDates.slice(-1)[0]);
+
+    if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
+      console.error(
+        `  🚨 timeseries for San Francisco County: SCRAPE_DATE ${datetime.getYYYYMMDD(
+          scrapeDate
+        )} is newer than last sample time ${datetime.getYYYYMMDD(lastDateInTimeseries)}. Using last sample anyway`
+      );
+      scrapeDate = lastDateInTimeseries;
+      scrapeDateString = datetime.getYYYYMMDD(scrapeDate);
+    }
+
+    if (datetime.scrapeDateIsBefore(firstDateInTimeseries)) {
+      throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
+    }
+    return scrapeDateString;
+  },
   scraper: {
     '0': async function() {
-      const cases = await fetch.json(this, this._urls.cases, 'cases', false);
-      const patients = await fetch.json(this, this._urls.patients, 'patients', false);
-      const tests = await fetch.json(this, this._urls.tests, 'tests', false);
-      const timeSeries = {};
-      cases.reduceRight(
-        (acc, cur) => {
-          const date = datetime.getYYYYMMDD(cur.date);
-          const field = cur.case_disposition === 'Death' ? 'deaths' : 'cases';
-          acc[field] += +cur.case_count;
-          if (!(date in timeSeries)) {
-            timeSeries[date] = {};
-          }
-          timeSeries[date][field] = acc[field];
-          return acc;
-        },
-        {
-          cases: 0,
-          deaths: 0
-        }
-      );
+      function sortBy(fld) {
+        return function(a, b) {
+          if (a[fld] === b[fld]) return 0;
+          return a[fld] < b[fld] ? -1 : 1;
+        };
+      }
+      let cases = await fetch.json(this, this._urls.cases, 'cases', false);
+      cases = cases.sort(sortBy('date'));
+
+      let patients = await fetch.json(this, this._urls.patients, 'patients', false);
+      patients = patients.sort(sortBy('reportdate'));
+
+      let tests = await fetch.json(this, this._urls.tests, 'tests', false);
+      tests = tests.sort(sortBy('result_date'));
+
+      function getCaseField(dt, fld) {
+        const c = cases.filter(cur => dt === datetime.getYYYYMMDD(cur.date) && cur.case_disposition === fld);
+        if (c.length === 0) return 0;
+        return c.reduce((acc, curr) => {
+          return acc + parse.number(curr.case_count);
+        }, 0);
+      }
+
+      function getTestedField(dt) {
+        const c = tests.filter(cur => dt === datetime.getYYYYMMDD(cur.result_date));
+        if (c.length === 0) return 0;
+        return c.reduce((acc, curr) => {
+          return acc + parse.number(curr.tests);
+        }, 0);
+      }
+
+      // I don't _believe_ that hospitalizations are incremental, they
+      // look to be current state.  Per
+      // https://data.sfgov.org/stories/s/wmxr-upyn, the numbers are
+      // below 100.  I also don't know what the different fields in
+      // the raw data set are, and am reluctant to include this data
+      // without understanding it.
+      // TODO (scraper) re-enable hospitalizations when we figure out what the data says.
+      /*
       patients.forEach(elt => {
         const date = datetime.getYYYYMMDD(elt.reportdate);
         if (!(date in timeSeries)) {
@@ -70,21 +111,20 @@ const scraper = {
           timeSeries[date].hospitalized += +elt.patientcount;
         }
       });
-      tests.reduceRight((acc, cur) => {
-        const date = datetime.getYYYYMMDD(cur.result_date);
-        acc += +cur.tests;
-        if (!(date in timeSeries)) {
-          timeSeries[date] = {};
-        }
-        timeSeries[date].tested = acc;
-        return acc;
-      }, 0);
+      */
 
+      const allDates = []
+        .concat(cases.map(c => c.date))
+        .concat(patients.map(p => p.reportdate))
+        .concat(tests.map(t => t.result_date))
+        .sort() // Assuming that all follow same yyyy-mm-dd format!
+        .map(s => s.split('T')[0]);
+
+      // const scrapeDateString = this._getScrapeDateString(datetime.scrapeDate() || new Date(), allDates);
       let scrapeDate = datetime.scrapeDate() || new Date();
       let scrapeDateString = datetime.getYYYYMMDD(new Date(scrapeDate));
-      const datesInTimeseries = Object.keys(timeSeries).sort();
-      const lastDateInTimeseries = new Date(datesInTimeseries.slice(-1)[0]);
-      const firstDateInTimeseries = new Date(datesInTimeseries[0]);
+      const firstDateInTimeseries = new Date(allDates[0]);
+      const lastDateInTimeseries = new Date(allDates.slice(-1)[0]);
 
       if (datetime.scrapeDateIsAfter(lastDateInTimeseries)) {
         console.error(
@@ -100,6 +140,26 @@ const scraper = {
         throw new Error(`Timeseries starts later than SCRAPE_DATE ${datetime.getYYYYMMDD(scrapeDate)}`);
       }
 
+      const timeSeries = {};
+      let runningCases = 0;
+      let runningDeaths = 0;
+      let runningTested = 0;
+      for (let d = firstDateInTimeseries; datetime.getYYYYMMDD(d) <= scrapeDateString; d.setDate(d.getDate() + 1)) {
+        const currYYYYMMDD = datetime.getYYYYMMDD(d);
+
+        runningCases += getCaseField(currYYYYMMDD, 'Confirmed');
+        runningDeaths += getCaseField(currYYYYMMDD, 'Death');
+        runningTested += getTestedField(currYYYYMMDD);
+
+        timeSeries[currYYYYMMDD] = {
+          cases: runningCases,
+          deaths: runningDeaths,
+          // hospitalized: 0,
+          tested: runningTested
+        };
+      }
+
+      // console.table(timeSeries);
       return timeSeries[scrapeDateString];
     }
   }


### PR DESCRIPTION
Hi there!

This is a substantial reorg of the code that you had.  The existing data sources don't necessarily include all of the dates for each type, and the sort order is different.  This code hammers through the data to provide a (hopefully) foolproof and correct running totals for cases, deaths, and tested.  The numbers returned approx match those on the dashboard.

https://data.sfgov.org/stories/s/fjki-2fab:

![image](https://user-images.githubusercontent.com/1637133/82709449-9d614080-9c4e-11ea-88e5-5d8376f76879.png)

vs this PR:

```
$ yarn start --location US/CA/san-francisco-county.js
...
 Total counts (tracked cases, may contain duplicates):
   - 2325 cases
   - 50554 tested
   - 0 recovered
   - 40 deaths
   - 0 active
```

I didn't include hospitalizations, as I didn't really trust the data ... wasn't sure, perhaps you have other thoughts!

Cheers! jz